### PR TITLE
ci: add legacy peer deps flag to install command

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,8 @@
       "use": "@vercel/static-build",
       "config": {
         "distDir": "build",
-        "nodeVersion": "18.x"
+        "nodeVersion": "18.x",
+        "installCommand": "npm install --legacy-peer-deps"
       }
     }
   ],


### PR DESCRIPTION
Add the `--legacy-peer-deps` flag to the `installCommand` in Vercel configuration to resolve potential dependency conflicts during the build process